### PR TITLE
Akit bump

### DIFF
--- a/src/main/java/team3176/robot/subsystems/vision/PhotonCameraIO.java
+++ b/src/main/java/team3176/robot/subsystems/vision/PhotonCameraIO.java
@@ -1,6 +1,7 @@
 package team3176.robot.subsystems.vision;
 
 import org.littletonrobotics.junction.AutoLog;
+import org.littletonrobotics.junction.LogTable;
 import org.photonvision.PhotonCamera;
 import org.photonvision.targeting.PhotonPipelineResult;
 
@@ -14,6 +15,7 @@ public class PhotonCameraIO {
   }
 
   public PhotonCameraIO(String name) {
+    LogTable.disableProtobufWarning();
     this.cam = new PhotonCamera(name);
   }
 

--- a/vendordeps/AdvantageKit.json
+++ b/vendordeps/AdvantageKit.json
@@ -1,7 +1,7 @@
 {
     "fileName": "AdvantageKit.json",
     "name": "AdvantageKit",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "uuid": "d820cc26-74e3-11ec-90d6-0242ac120003",
     "frcYear": "2024",
     "mavenUrls": [],
@@ -10,24 +10,24 @@
         {
             "groupId": "org.littletonrobotics.akit.junction",
             "artifactId": "wpilib-shim",
-            "version": "3.1.0"
+            "version": "3.1.1"
         },
         {
             "groupId": "org.littletonrobotics.akit.junction",
             "artifactId": "junction-core",
-            "version": "3.1.0"
+            "version": "3.1.1"
         },
         {
             "groupId": "org.littletonrobotics.akit.conduit",
             "artifactId": "conduit-api",
-            "version": "3.1.0"
+            "version": "3.1.1"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "org.littletonrobotics.akit.conduit",
             "artifactId": "conduit-wpilibio",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "skipInvalidPlatforms": false,
             "isJar": false,
             "validPlatforms": [


### PR DESCRIPTION
Bumping version

We are logging the full Photonvision result as a protobuf. protobuf logging has a warning on it to check for loop overruns. This could be a part of that. need to test on hardware

from akit release 
"
This release fixes several issues, and we recommend that all teams update to the latest version. See the [release post](https://www.chiefdelphi.com/t/advantagekit-2024-log-replay-again/442968/206) for more details.

Fixed alliance and station numbers published to the "FMSInfo" table
Added warning when logging data using protobuf
Fixed RIO console capture loop overruns after removing SD card"